### PR TITLE
transmit(): prepend length byte in variable packet length mode internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `transmit()`: prepend length byte in variable packet length mode internally
+  to avoid accidental incomplete transmissions and TX FIFO underflows
 
 ## [1.2.0] - 2020-12-02
 ### Added

--- a/examples/transmit_variable_length.py
+++ b/examples/transmit_variable_length.py
@@ -18,9 +18,9 @@ with cc1101.CC1101() as transceiver:
     print("symbol rate", transceiver.get_symbol_rate_baud(), "Baud")
     print("modulation format", transceiver.get_modulation_format().name)
     print("starting transmission")
-    transceiver.transmit(b"\x0a\xff\x00 message")
+    transceiver.transmit(b"\xff\xaa\x00 message")
     time.sleep(1.0)
-    transceiver.transmit(bytes([0x02, 0b10101010, 0xFF]))
+    transceiver.transmit(bytes([0, 0b10101010, 0xFF]))
     for i in range(16):
         time.sleep(1.0)
-        transceiver.transmit(bytes([1, i]))
+        transceiver.transmit(bytes([i, i, i]))

--- a/tests/test_transmit.py
+++ b/tests/test_transmit.py
@@ -19,19 +19,6 @@ def test_transmit_empty_payload(transceiver):
             transceiver.transmit([])
 
 
-@pytest.mark.parametrize("payload", (b"\0\x01\x02", [0, 127]))
-def test_transmit_first_null(transceiver, payload):
-    with unittest.mock.patch.object(
-        transceiver,
-        "get_packet_length_mode",
-        return_value=cc1101.options.PacketLengthMode.VARIABLE,
-    ), unittest.mock.patch.object(
-        transceiver, "get_packet_length_bytes", return_value=21
-    ):
-        with pytest.raises(ValueError, match=r"\bfirst byte\b.*\bmust not be null\b"):
-            transceiver.transmit(payload)
-
-
 @pytest.mark.parametrize(
     ("max_packet_length", "payload"),
     ((3, "\x04\x01\x02\x03"), (4, [7, 21, 42, 0, 0, 1, 2, 3])),
@@ -107,6 +94,6 @@ def test_transmit_variable(transceiver, payload):
         transceiver.transmit(payload)
     assert transceiver._spi.xfer.call_args_list == [
         unittest.mock.call([0x3B]),  # flush
-        unittest.mock.call([0x3F | 0x40] + list(payload)),
+        unittest.mock.call([0x3F | 0x40] + [len(payload)] + list(payload)),
         unittest.mock.call([0x35]),  # start transmission
     ]


### PR DESCRIPTION
to avoid accidental incomplete transmissions and TX FIFO underflows