### PR TITLE
Parametrize "max_speed_hz" during instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - declare compatibility with `python3.11`
+- allow parametrization of `spi_max_speed_hz` during `C1101` class instantiation
+  to solve [issue-128] 
 
 ### Changed
 - `CC1101.transmit`: raise `RuntimeError` instead of `Exception` when
@@ -133,3 +135,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.2.0]: https://github.com/fphammerle/python-cc1101/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/fphammerle/python-cc1101/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/fphammerle/python-cc1101/releases/tag/v1.0.0
+[issue-128]: https://github.com/fphammerle/python-cc1101/issues/128

--- a/cc1101/__init__.py
+++ b/cc1101/__init__.py
@@ -156,7 +156,11 @@ class CC1101:
     _PATABLE_LENGTH_BYTES = 8
 
     def __init__(
-        self, spi_bus: int = 0, spi_chip_select: int = 0, lock_spi_device: bool = False
+        self,
+        spi_bus: int = 0,
+        spi_chip_select: int = 0,
+        lock_spi_device: bool = False,
+        spi_max_speed_hz: int = 55700,
     ) -> None:
         """
         lock_spi_device:
@@ -177,6 +181,7 @@ class CC1101:
             >>>     # lock removed
         """
         self._spi = spidev.SpiDev()
+        self._spi_max_speed_hz = int(spi_max_speed_hz)
         self._spi_bus = int(spi_bus)
         # > The BCM2835 core common to all Raspberry Pi devices has 3 SPI Controllers:
         # > SPI0, with two hardware chip selects, [...]
@@ -558,7 +563,7 @@ class CC1101:
             # lock removed in __exit__ by SpiDev.close()
             fcntl.flock(self._spi.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         try:
-            self._spi.max_speed_hz = 55700  # empirical
+            self._spi.max_speed_hz = self._spi_max_speed_hz
             self._reset()
             self._verify_chip()
             self._configure_defaults()


### PR DESCRIPTION
A default value for "max_speed_hz" might not be appropriate for all hardware platforms.
Allow parametrization of "max_speed_hz" during instantiation of the "CC1101" class.