### PR TITLE
Define all state in MainRadioControlStateMachineState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Fixed
 - defined all state in MainRadioControlStateMachineState as in datasheet page 93 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- defined all state in MainRadioControlStateMachineState as in datasheet page 93 
+
 ### Removed
 - compatibility with `python3.7` & `python3.8`
 

--- a/cc1101/__init__.py
+++ b/cc1101/__init__.py
@@ -58,15 +58,29 @@ class MainRadioControlStateMachineState(enum.IntEnum):
 
     # see "Figure 13: Simplified State Diagram"
     # and "Figure 25: Complete Radio Control State Diagram"
+    SLEEP = 0x00
     IDLE = 0x01
+    XOFF = 0x02
+    VCOON_MC = 0x03
+    REGON_MC = 0x04
+    MANCAL = 0x05
+    VCOON = 0x06
+    REGON = 0x07
     STARTCAL = 0x08  # after IDLE
     BWBOOST = 0x09  # after STARTCAL
     FS_LOCK = 0x0A
+    IFADCON = 0x0B
+    ENDCAL = 0x0C
     RX = 0x0D
+    RX_END = 0x0E
+    RX_RST = 0x0F
+    TXRX_SWITCH = 0x10
     RXFIFO_OVERFLOW = 0x11
+    FSTXON = 0x12
     TX = 0x13
-    # TXFIFO_UNDERFLOW = 0x16
-
+    TX_END = 0x14
+    RXTX_SWITCH = 0x15
+    TXFIFO_UNDERFLOW = 0x16
 
 class _ReceivedPacket:  # unstable
     # "Table 31: Typical RSSI_offset Values"

--- a/cc1101/__init__.py
+++ b/cc1101/__init__.py
@@ -372,7 +372,8 @@ class CC1101:
             math.log2(real / cls._CRYSTAL_OSCILLATOR_FREQUENCY_HERTZ) + 20
         )
         mantissa = round(
-            real * 2**28 / cls._CRYSTAL_OSCILLATOR_FREQUENCY_HERTZ / 2**exponent - 256
+            real * 2**28 / cls._CRYSTAL_OSCILLATOR_FREQUENCY_HERTZ / 2**exponent
+            - 256
         )
         if mantissa == 256:
             exponent += 1

--- a/cc1101/__init__.py
+++ b/cc1101/__init__.py
@@ -82,6 +82,7 @@ class MainRadioControlStateMachineState(enum.IntEnum):
     RXTX_SWITCH = 0x15
     TXFIFO_UNDERFLOW = 0x16
 
+
 class _ReceivedPacket:  # unstable
     # "Table 31: Typical RSSI_offset Values"
     _RSSI_OFFSET_dB = 74


### PR DESCRIPTION
sometimes when a transmit start, the chip is in a state not defined in MainRadioControlStateMachineState so we got an error. This patch should solve the issue.